### PR TITLE
NEW: Reverse a project into a Cookiecutter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Just run `wiggle` via manageproject CLI, e.g.:
 ```
 
 
+## Helper: Reverse a project into a Cookiecutter template
+
+A existing managed project can be converted back to a Cookiecutter template, e.g.:
+```bash
+~/manageprojects$ ./cli.py reverse ~/my_new_project/ ~/cookiecutter_template/
+```
+
+
 ## Links
 
 * Own Cookiecutter Templates: https://github.com/jedie/cookiecutter_templates

--- a/manageprojects/cli/cli_app.py
+++ b/manageprojects/cli/cli_app.py
@@ -18,6 +18,7 @@ import manageprojects
 from manageprojects import __version__
 from manageprojects.cookiecutter_templates import (
     clone_managed_project,
+    reverse_managed_project,
     start_managed_project,
     update_managed_project,
 )
@@ -263,6 +264,21 @@ def clone_project(
         password=password,
         config_file=config_file,
         no_input=no_input,
+    )
+
+
+@app.command()
+def reverse(
+    project_path: Path,
+    destination: Path,
+):
+    """
+    Create a cookiecutter template from a managed project.
+    """
+    log_config()
+    return reverse_managed_project(
+        project_path=project_path,
+        destination=destination,
     )
 
 

--- a/manageprojects/cookiecutter_generator.py
+++ b/manageprojects/cookiecutter_generator.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from bx_py_utils.path import assert_is_dir
+from pathspec import PathSpec
+from rich import print  # noqa
+from rich.pretty import pprint
+
+from manageprojects.utilities.gitignore import get_gitignore
+
+
+def iter_context(*, context: dict, prefix='') -> tuple:
+    for key, value in context.items():
+        if key.startswith('_'):
+            continue
+
+        if isinstance(value, dict):
+            yield from iter_context(context=value, prefix=f'{key}.')
+        else:
+            yield (f'{prefix}{key}', value)
+
+
+def generate_reverse_info(*, cookiecutter_context: dict) -> tuple:
+    reverse_info = [
+        (value, '{{ %s }}' % key) for key, value in iter_context(context=cookiecutter_context)
+    ]
+    reverse_info.sort(key=lambda x: len(x[1]))
+    return tuple(reverse_info)
+
+
+def replace_path(*, path: Path, reverse_info: tuple) -> Path:
+    new_parts = []
+    for part in path.parts:
+        for src_str, dst_str in reverse_info:
+            part = part.replace(src_str, dst_str)
+        new_parts.append(part)
+    return Path(*new_parts)
+
+
+def build_dst_path(*, source_path: Path, item: Path, destination: Path, reverse_info: tuple):
+    rel_path = item.relative_to(source_path)
+    new_path = replace_path(path=rel_path, reverse_info=reverse_info)
+    dst_path = destination / new_path
+    return dst_path
+
+
+def copy_replaced(src_path, dst_path, reverse_info):
+    dst_parent = dst_path.parent
+    dst_parent.mkdir(parents=True, exist_ok=True)
+
+    content = src_path.read_text(encoding='UTF-8')
+
+    for src_str, dst_str in reverse_info:
+        content = content.replace(src_str, dst_str)
+
+    dst_path.write_text(content, encoding='UTF-8')
+
+
+def create_cookiecutter_template(
+    *,
+    source_path: Path,
+    destination: Path,
+    cookiecutter_context: dict,
+):
+    source_path = source_path.resolve()
+    assert_is_dir(source_path)
+    assert not destination.exists(), f'Destination {destination} already exists!'
+
+    reverse_info = generate_reverse_info(cookiecutter_context=cookiecutter_context)
+
+    print('Use this reverse context:')
+    pprint(reverse_info)
+
+    path_spec: PathSpec = get_gitignore(source_path)
+
+    for item in source_path.rglob('*'):
+        if path_spec.match_file(item):
+            continue
+
+        dst_path = build_dst_path(
+            source_path=source_path,
+            item=item,
+            destination=destination,
+            reverse_info=reverse_info,
+        )
+        if item.is_dir():
+            dst_path.mkdir(parents=True, exist_ok=True)
+        elif item.is_file():
+            print(item.relative_to(source_path), '->', dst_path)
+            copy_replaced(src_path=item, dst_path=dst_path, reverse_info=reverse_info)
+        else:
+            print(f'Ignore: {item}')

--- a/manageprojects/cookiecutter_templates.py
+++ b/manageprojects/cookiecutter_templates.py
@@ -7,6 +7,7 @@ from typing import Optional
 from rich import print as rprint
 
 from manageprojects.cookiecutter_api import execute_cookiecutter
+from manageprojects.cookiecutter_generator import create_cookiecutter_template
 from manageprojects.data_classes import (
     CookiecutterResult,
     GenerateTemplatePatchResult,
@@ -227,3 +228,29 @@ def clone_managed_project(
     )
     print(f'{project_path} successfully cloned to {destination_path}')
     return result
+
+
+def reverse_managed_project(
+    *,
+    project_path: Path,
+    destination: Path,
+):
+    """
+    Create a cookiecutter template from a managed project.
+    """
+    rprint(f'Create cookiecutter template from {project_path} in {destination}')
+    if destination.exists():
+        print(f'ERROR: Destination {destination} already exists!')
+        sys.exit(1)
+
+    toml = PyProjectToml(project_path=project_path)
+    meta: ManageProjectsMeta = toml.get_mp_meta()
+
+    cookiecutter_context = meta.cookiecutter_context
+    assert cookiecutter_context, f'Missing cookiecutter context in {toml.path}'
+
+    create_cookiecutter_template(
+        source_path=project_path,
+        destination=destination,
+        cookiecutter_context=cookiecutter_context,
+    )

--- a/manageprojects/tests/test_cli_main_help_1.snapshot.txt
+++ b/manageprojects/tests/test_cli_main_help_1.snapshot.txt
@@ -16,6 +16,7 @@
 │ install           Run pip-sync and install 'manageprojects' via pip as editable.                 │
 │ mypy              Run Mypy (configured in pyproject.toml)                                        │
 │ publish           Build and upload this project to PyPi                                          │
+│ reverse           Create a cookiecutter template from a managed project.                         │
 │ start-project     Start a new "managed" project via a CookieCutter Template                      │
 │ test              Run unittests                                                                  │
 │ update            Update the development environment by calling: - pip-compile production.in     │

--- a/manageprojects/tests/test_cookiecutter_generator.py
+++ b/manageprojects/tests/test_cookiecutter_generator.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from manageprojects.cookiecutter_generator import (
+    build_dst_path,
+    generate_reverse_info,
+    iter_context,
+    replace_path,
+)
+from manageprojects.tests.base import BaseTestCase
+
+
+class CookiecutterGeneratorTestCase(BaseTestCase):
+    def test_iter_context(self):
+        result = list(
+            iter_context(
+                context={
+                    'cookiecutter': {
+                        '_template': 'https://github.com/jedie/cookiecutter_templates/',
+                        'package_name': 'PyInventory',
+                        'package_url': 'https://github.com/jedie/PyInventory',
+                        'issues_url': 'https://github.com/jedie/PyInventory/issues',
+                    }
+                }
+            )
+        )
+        self.assertEqual(
+            result,
+            [
+                ('cookiecutter.package_name', 'PyInventory'),
+                ('cookiecutter.package_url', 'https://github.com/jedie/PyInventory'),
+                ('cookiecutter.issues_url', 'https://github.com/jedie/PyInventory/issues'),
+            ],
+        )
+
+    def test_generate_reverse_info(self):
+        reverse_info = generate_reverse_info(
+            cookiecutter_context={
+                'cookiecutter': {
+                    '_template': 'https://github.com/jedie/cookiecutter_templates/',
+                    'package_name': 'PyInventory',
+                    'package_url': 'https://github.com/jedie/PyInventory',
+                    'issues_url': 'https://github.com/jedie/PyInventory/issues',
+                }
+            }
+        )
+        self.assertEqual(
+            reverse_info,
+            (
+                ('https://github.com/jedie/PyInventory/issues', '{{ cookiecutter.issues_url }}'),
+                ('https://github.com/jedie/PyInventory', '{{ cookiecutter.package_url }}'),
+                ('PyInventory', '{{ cookiecutter.package_name }}'),
+            ),
+        )
+
+    def test_replace_path(self):
+        path = replace_path(
+            path=Path('foo', 'bar', 'baz'),
+            reverse_info=(
+                ('foo', '{{ package_name }}'),
+                ('bar', '{{ dir_name }}'),
+            ),
+        )
+        self.assertEqual(path, Path('{{ package_name }}/{{ dir_name }}/baz'))
+
+    def test_build_dst_path(self):
+        path = build_dst_path(
+            source_path=Path('/the/source/path/'),
+            item=Path('/the/source/path/foo/bar/test.py'),
+            destination=Path('/the/destination'),
+            reverse_info=(
+                ('foo', '{{ package_name }}'),
+                ('bar', '{{ dir_name }}'),
+            ),
+        )
+        self.assertEqual(
+            path,
+            Path('/the/destination/{{ package_name }}/{{ dir_name }}/test.py'),
+        )

--- a/manageprojects/utilities/gitignore.py
+++ b/manageprojects/utilities/gitignore.py
@@ -1,0 +1,22 @@
+import logging
+from functools import lru_cache
+from pathlib import Path
+
+from pathspec import GitIgnoreSpec, PathSpec
+
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache
+def get_gitignore(root: Path) -> PathSpec:
+    gitignore = root / '.gitignore'
+
+    lines = []
+    if gitignore.is_file():
+        with gitignore.open(encoding='utf-8') as f:
+            lines = f.readlines()
+    else:
+        print(f'WARNING: No .gitignore found in {root}')
+
+    return GitIgnoreSpec.from_lines(lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manageprojects"
-version = "0.4.0"
+version = "0.5.0"
 description = "Manage Python / Django projects"
 readme = "README.md"
 authors = [
@@ -13,6 +13,7 @@ dependencies = [
     "bx_py_utils",  # https://github.com/boxine/bx_py_utils
     "rich",
     "typer[all]",  # https://github.com/tiangolo/typer
+    "pathspec",  # https://github.com/cpburnz/python-pathspec
 ]
 [project.optional-dependencies]
 dev = [

--- a/requirements.develop.txt
+++ b/requirements.develop.txt
@@ -201,33 +201,30 @@ coveralls==3.3.1 \
     --hash=sha256:b32a8bb5d2df585207c119d6c01567b81fba690c9c10a753bfe27a335bfc43ea \
     --hash=sha256:f42015f31d386b351d4226389b387ae173207058832fbf5c8ec4b40e27b16026
     # via manageprojects (pyproject.toml)
-cryptography==38.0.4 \
-    --hash=sha256:0e70da4bdff7601b0ef48e6348339e490ebfb0cbe638e083c9c41fb49f00c8bd \
-    --hash=sha256:10652dd7282de17990b88679cb82f832752c4e8237f0c714be518044269415db \
-    --hash=sha256:175c1a818b87c9ac80bb7377f5520b7f31b3ef2a0004e2420319beadedb67290 \
-    --hash=sha256:1d7e632804a248103b60b16fb145e8df0bc60eed790ece0d12efe8cd3f3e7744 \
-    --hash=sha256:1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb \
-    --hash=sha256:2ec2a8714dd005949d4019195d72abed84198d877112abb5a27740e217e0ea8d \
-    --hash=sha256:2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70 \
-    --hash=sha256:2fb481682873035600b5502f0015b664abc26466153fab5c6bc92c1ea69d478b \
-    --hash=sha256:3178d46f363d4549b9a76264f41c6948752183b3f587666aff0555ac50fd7876 \
-    --hash=sha256:4367da5705922cf7070462e964f66e4ac24162e22ab0a2e9d31f1b270dd78083 \
-    --hash=sha256:4eb85075437f0b1fd8cd66c688469a0c4119e0ba855e3fef86691971b887caf6 \
-    --hash=sha256:50a1494ed0c3f5b4d07650a68cd6ca62efe8b596ce743a5c94403e6f11bf06c1 \
-    --hash=sha256:53049f3379ef05182864d13bb9686657659407148f901f3f1eee57a733fb4b00 \
-    --hash=sha256:6391e59ebe7c62d9902c24a4d8bcbc79a68e7c4ab65863536127c8a9cd94043b \
-    --hash=sha256:67461b5ebca2e4c2ab991733f8ab637a7265bb582f07c7c88914b5afb88cb95b \
-    --hash=sha256:78e47e28ddc4ace41dd38c42e6feecfdadf9c3be2af389abbfeef1ff06822285 \
-    --hash=sha256:80ca53981ceeb3241998443c4964a387771588c4e4a5d92735a493af868294f9 \
-    --hash=sha256:8a4b2bdb68a447fadebfd7d24855758fe2d6fecc7fed0b78d190b1af39a8e3b0 \
-    --hash=sha256:8e45653fb97eb2f20b8c96f9cd2b3a0654d742b47d638cf2897afbd97f80fa6d \
-    --hash=sha256:998cd19189d8a747b226d24c0207fdaa1e6658a1d3f2494541cb9dfbf7dcb6d2 \
-    --hash=sha256:a10498349d4c8eab7357a8f9aa3463791292845b79597ad1b98a543686fb1ec8 \
-    --hash=sha256:b4cad0cea995af760f82820ab4ca54e5471fc782f70a007f31531957f43e9dee \
-    --hash=sha256:bfe6472507986613dc6cc00b3d492b2f7564b02b3b3682d25ca7f40fa3fd321b \
-    --hash=sha256:c9e0d79ee4c56d841bd4ac6e7697c8ff3c8d6da67379057f29e66acffcd1e9a7 \
-    --hash=sha256:ca57eb3ddaccd1112c18fc80abe41db443cc2e9dcb1917078e02dfa010a4f353 \
-    --hash=sha256:ce127dd0a6a0811c251a6cddd014d292728484e530d80e872ad9806cfb1c5b3c
+cryptography==39.0.0 \
+    --hash=sha256:1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b \
+    --hash=sha256:1ee1fd0de9851ff32dbbb9362a4d833b579b4a6cc96883e8e6d2ff2a6bc7104f \
+    --hash=sha256:407cec680e811b4fc829de966f88a7c62a596faa250fc1a4b520a0355b9bc190 \
+    --hash=sha256:50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f \
+    --hash=sha256:6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f \
+    --hash=sha256:754978da4d0457e7ca176f58c57b1f9de6556591c19b25b8bcce3c77d314f5eb \
+    --hash=sha256:76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c \
+    --hash=sha256:7dacfdeee048814563eaaec7c4743c8aea529fe3dd53127313a792f0dadc1773 \
+    --hash=sha256:80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72 \
+    --hash=sha256:844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8 \
+    --hash=sha256:875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717 \
+    --hash=sha256:887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9 \
+    --hash=sha256:ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856 \
+    --hash=sha256:bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96 \
+    --hash=sha256:c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288 \
+    --hash=sha256:e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39 \
+    --hash=sha256:e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e \
+    --hash=sha256:e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce \
+    --hash=sha256:f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1 \
+    --hash=sha256:f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de \
+    --hash=sha256:f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df \
+    --hash=sha256:f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf \
+    --hash=sha256:fec8b932f51ae245121c4671b4bbc030880f363354b2f0e0bd1366017d891458
     # via secretstorage
 darker==1.6.1 \
     --hash=sha256:9f4805f3f105c9107f2c4868bcdadac91f4aa189940e6080e2e5b2f5007bd509 \
@@ -268,9 +265,9 @@ idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
     # via requests
-importlib-metadata==5.2.0 \
-    --hash=sha256:0eafa39ba42bf225fc00e67f701d71f85aead9f878569caf13c3724f704b970f \
-    --hash=sha256:404d48d62bba0b7a77ff9d405efd91501bef2e67ff4ace0bed40a0cf28c3c7cd
+importlib-metadata==6.0.0 \
+    --hash=sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad \
+    --hash=sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d
     # via
     #   keyring
     #   twine
@@ -402,7 +399,9 @@ packaging==22.0 \
 pathspec==0.10.3 \
     --hash=sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6 \
     --hash=sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6
-    # via black
+    # via
+    #   black
+    #   manageprojects (pyproject.toml)
 pep517==0.13.0 \
     --hash=sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b \
     --hash=sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59
@@ -415,9 +414,9 @@ pip-tools==6.12.1 \
     --hash=sha256:88efb7b29a923ffeac0713e6f23ef8529cc6175527d42b93f73756cc94387293 \
     --hash=sha256:f0c0c0ec57b58250afce458e2e6058b1f30a4263db895b7d72fd6311bf1dc6f7
     # via manageprojects (pyproject.toml)
-pkginfo==1.9.2 \
-    --hash=sha256:ac03e37e4d601aaee40f8087f63fc4a2a6c9814dda2c8fa6aab1b1829653bdfa \
-    --hash=sha256:d580059503f2f4549ad6e4c106d7437356dbd430e2c7df99ee1efe03d75f691e
+pkginfo==1.9.6 \
+    --hash=sha256:4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546 \
+    --hash=sha256:8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046
     # via twine
 platformdirs==2.6.2 \
     --hash=sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490 \
@@ -446,15 +445,15 @@ pyflakes==3.0.1 \
     --hash=sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf \
     --hash=sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd
     # via flake8
-pygments==2.13.0 \
-    --hash=sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1 \
-    --hash=sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42
+pygments==2.14.0 \
+    --hash=sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297 \
+    --hash=sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717
     # via
     #   readme-renderer
     #   rich
-pyproject-api==1.2.1 \
-    --hash=sha256:093c047d192ceadcab7afd6b501276bf2ce44adf41cb9c313234518cddd20818 \
-    --hash=sha256:155d5623453173b7b4e9379a3146ccef2d52335234eb2d03d6ba730e7dad179c
+pyproject-api==1.4.0 \
+    --hash=sha256:ac85c1f82e0291dbae5a7739dbb9a990e11ee4034c9b5599ea714f07a24ecd71 \
+    --hash=sha256:c34226297781efdd1ba4dfb74ce21076d9a8360e2125ea31803c1a02c76b2460
     # via tox
 python-creole==1.4.10 \
     --hash=sha256:6429aedc7cef578fe681d7781ad12dbea6ee54e03937b0e1b697e4cae5ff80bb \
@@ -592,9 +591,9 @@ setuptools==65.6.3 \
     # via
     #   pip-tools
     #   safety
-shellingham==1.5.0 \
-    --hash=sha256:72fb7f5c63103ca2cb91b23dee0c71fe8ad6fbfd46418ef17dbe40db51592dad \
-    --hash=sha256:a8f02ba61b69baaa13facdba62908ca8690a94b8119b69f5ec5873ea85f7391b
+shellingham==1.5.0.post1 \
+    --hash=sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744 \
+    --hash=sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28
     # via typer
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -627,9 +626,9 @@ tomlkit==0.11.6 \
     --hash=sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b \
     --hash=sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73
     # via manageprojects (pyproject.toml)
-tox==4.1.1 \
-    --hash=sha256:5d214ce3e480e3b2cce72dbc9e832296387e7311f76b70de4a649636d02e34c9 \
-    --hash=sha256:d6b9f9f77796fcb1260d46f12dd4d6ebcc16bb73e72f7a683421b365491a912e
+tox==4.2.6 \
+    --hash=sha256:ecf224a4f3a318adcdd71aa8fe15ffd31f14afd6a9845a43ffd63950a7325538 \
+    --hash=sha256:fb79b3e4b788491949576a9c80c2d56419eac994567c3591e24bb2788b5901d0
     # via manageprojects (pyproject.toml)
 twine==4.0.2 \
     --hash=sha256:929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,9 +102,13 @@ markupsafe==2.1.1 \
     --hash=sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a \
     --hash=sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7
     # via jinja2
-pygments==2.13.0 \
-    --hash=sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1 \
-    --hash=sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42
+pathspec==0.10.3 \
+    --hash=sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6 \
+    --hash=sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6
+    # via manageprojects (pyproject.toml)
+pygments==2.14.0 \
+    --hash=sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297 \
+    --hash=sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717
     # via rich
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
@@ -166,9 +170,9 @@ rich==12.6.0 \
     # via
     #   manageprojects (pyproject.toml)
     #   typer
-shellingham==1.5.0 \
-    --hash=sha256:72fb7f5c63103ca2cb91b23dee0c71fe8ad6fbfd46418ef17dbe40db51592dad \
-    --hash=sha256:a8f02ba61b69baaa13facdba62908ca8690a94b8119b69f5ec5873ea85f7391b
+shellingham==1.5.0.post1 \
+    --hash=sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744 \
+    --hash=sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28
     # via typer
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \


### PR DESCRIPTION
A existing managed project can be converted back to a Cookiecutter template, e.g.:
```bash
~/manageprojects$ ./cli.py reverse ~/my_new_project/ ~/cookiecutter_template/
```