### PR TITLE
Bugfix and enhance "setup_python.py"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Besides this, `manageprojects` also includes other generic helper for Python pac
 
  * `publish_package()` - Build and upload a new release to PyPi, but with many pre-checks.
  * `format-file` - Format/Check a Python source file with Darker & Co., useful as IDE action.
- * `install_python.py` - [Install Python interpreter, if needed, from official Python FTP server, verified.](https://github.com/jedie/manageprojects/blob/main/docs/install_python.md)
- * `setup_python.py` - [Download and setup redistributable Python Interpreter, if needed.](https://github.com/jedie/manageprojects/blob/main/docs/setup_python.md)
+ * `install_python.py` - [One file and no dependencies to install Python, if needed, from official Python FTP server, verified.](https://github.com/jedie/manageprojects/blob/main/docs/install_python.md)
+ * `setup_python.py` - [One file and no dependencies to download and setup redistributable Python, if needed.](https://github.com/jedie/manageprojects/blob/main/docs/setup_python.md)
 
 Read below the `Helper` section.
 
@@ -347,6 +347,8 @@ See also git tags: https://github.com/jedie/manageprojects/tags
 
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
+* [v0.19.1](https://github.com/jedie/manageprojects/compare/v0.19.0...v0.19.1)
+  * 2024-09-15 - Bugfix and enhance "setup_python.py"
 * [v0.19.0](https://github.com/jedie/manageprojects/compare/v0.18.0...v0.19.0)
   * 2024-09-15 - NEW: setup_python.py
   * 2024-09-15 - Update requirements
@@ -369,15 +371,15 @@ See also git tags: https://github.com/jedie/manageprojects/tags
   * 2023-12-30 - Fix typos
 * [v0.17.1](https://github.com/jedie/manageprojects/compare/v0.17.0...v0.17.1)
   * 2023-12-29 - Still support Python v3.9
+
+<details><summary>Expand older history entries ...</summary>
+
 * [v0.17.0](https://github.com/jedie/manageprojects/compare/v0.16.2...v0.17.0)
   * 2023-12-21 - Bugfix: Don't loose the "[manageprojects]" content on overwrite-update
   * 2023-12-21 - typing: Optional -> None
   * 2023-12-21 - Unify BASE_PATH / PACKAGE_ROOT etc.
   * 2023-12-21 - Apply manageprojects updates: Skip Python 3.9 support
   * 2023-12-21 - Update requirements
-
-<details><summary>Expand older history entries ...</summary>
-
 * [v0.16.2](https://github.com/jedie/manageprojects/compare/v0.16.1...v0.16.2)
   * 2023-12-16 - Update pre-commit-config
   * 2023-12-16 - Skip test_readme_history() on CI

--- a/docs/setup_python.md
+++ b/docs/setup_python.md
@@ -1,7 +1,7 @@
 # Boot Redistributable Python
 
-This is a standalone script (no dependencies) to download and setup
-https://github.com/indygreg/python-build-standalone/ redistributable Python interpreter.
+This is a standalone script (one file and no dependencies) to download and setup
+https://github.com/indygreg/python-build-standalone/ redistributable Python.
 But only if it's needed!
 
 Minimal version to used this script is Python v3.9.
@@ -90,14 +90,11 @@ If the latest Python version is already installed, we skip the download.
 
 All downloads will be done with a secure connection (SSL) and server authentication.
 
+We check if we have "zstd" or "gzip" installed for decompression and prefer "zstd" over "gzip".
+
 If the latest Python version is already installed, we skip the download.
 
 Download will be done in a temporary directory.
-
-We download the archive file and the hash file for verification:
-
-* Archive extension: `.tar.zst`
-* Hash extension: `.tar.zst.sha256`
 
 We check the file hash after downloading the archive.
 
@@ -110,6 +107,13 @@ We add the file `info.json` with all relevant information.
 We add a shell script to `~/.local/bin/pythonX.XX` to start the Python interpreter.
 
 We display version information from Python and pip on `stderr`.
+
+There exists two different directory structures:
+
+* `./python/install/bin/python3`
+* `./python/bin/python3`
+
+We handle both cases and move all contents to the final destination.
 
 The extracted Python will be moved to the final destination in `~/.local/pythonX.XX/`.
 

--- a/manageprojects/__init__.py
+++ b/manageprojects/__init__.py
@@ -3,5 +3,5 @@
     Manage Python / Django projects
 """
 
-__version__ = '0.19.0'
+__version__ = '0.19.1'
 __author__ = 'Jens Diemer <mamageprojects@jensdiemer.de>'

--- a/manageprojects/tests/docwrite_macros_setup_python.py
+++ b/manageprojects/tests/docwrite_macros_setup_python.py
@@ -7,7 +7,7 @@ from bx_py_utils.doc_write.data_structures import MacroContext
 from bx_py_utils.path import assert_is_file
 
 from manageprojects import setup_python
-from manageprojects.setup_python import ARCHIVE_EXTENSION, ARCHIVE_HASH_EXTENSION, LASTEST_RELEASE_URL
+from manageprojects.setup_python import LASTEST_RELEASE_URL
 
 
 PROG = Path(setup_python.__file__).name
@@ -47,9 +47,3 @@ def optimization_priority(macro_context: MacroContext):
     yield ''
     for number, optimization in enumerate(setup_python.OPTIMIZATION_PRIORITY, 1):
         yield f'{number}. `{optimization}`'
-
-
-def extension_info(macro_context: MacroContext):
-    yield ''
-    yield f'* Archive extension: `{ARCHIVE_EXTENSION}`'
-    yield f'* Hash extension: `{ARCHIVE_HASH_EXTENSION}`'


### PR DESCRIPTION
Bugfix fallback in `get_best_variant()`

Check if local python executable is in PATH and warn if not. Don't download if again, if it's not in PATH.

Check if "zstd" or "gzip" is installed for decompression and prefer "zstd" over "gzip".

Handle different directory structures in archive: with and without `install` directory.